### PR TITLE
Updates enabling build and install

### DIFF
--- a/protoc/lisp/Makefile
+++ b/protoc/lisp/Makefile
@@ -1,9 +1,9 @@
 
 # Directory into which the Lisp protocol buffer plugin will be installed.
-INSTALL_ROOT = $(HOME)/local/software/package/protoc-gen-lisp
+INSTALL_ROOT ?= $(HOME)/local/software/package/protoc-gen-lisp
 
 # Directory where Google's protocol buffer compiler is installed.
-PROTOC_ROOT = $(HOME)/local/software/package/google-protobuf
+PROTOC_ROOT ?= $(HOME)/local/software/package/google-protobuf
 
 PROTOC_INCLUDE = $(PROTOC_ROOT)/include
 PROTOC_LIB = $(PROTOC_ROOT)/lib

--- a/protoc/lisp/message.cc
+++ b/protoc/lisp/message.cc
@@ -94,7 +94,7 @@ struct ExtensionRangeSorter {
 // (and also to protect against recursion).
 static bool HasRequiredFields(
     const Descriptor* type,
-    hash_set<const Descriptor*>* already_seen) {
+    std::unordered_set<const Descriptor*>* already_seen) {
   if (already_seen->count(type) > 0) {
     // Since the first occurrence of a required field causes the whole
     // function to return true, we can assume that if the type is already
@@ -126,7 +126,7 @@ static bool HasRequiredFields(
 }
 
 static bool HasRequiredFields(const Descriptor* type) {
-  hash_set<const Descriptor*> already_seen;
+  std::unordered_set<const Descriptor*> already_seen;
   return HasRequiredFields(type, &already_seen);
 }
 


### PR DESCRIPTION
With these changes I'm able to build and install locally.  See the following package which will build and install protoc-gen-lisp on Arch linux (which depends on these changes).

https://aur.archlinux.org/packages/cl-protobuf-git/