### PR TITLE
Add :initarg to fields on protobuf defined classes

### DIFF
--- a/protoc/lisp/enum_field.cc
+++ b/protoc/lisp/enum_field.cc
@@ -77,6 +77,7 @@ void EnumFieldGenerator::GenerateSlot(io::Printer* printer) const {
       variables_,
       "($name$\n"
       " :accessor $name$\n"
+      " :initarg :$name$\n"
       " :initform $package$::$default$\n"
       " :type $package$::$type$)\n");
 }
@@ -144,6 +145,7 @@ void RepeatedEnumFieldGenerator::GenerateSlot(io::Printer* printer) const {
       variables_,
       "($name$\n"
       " :accessor $name$\n"
+      " :initarg :$name$\n"
       " :initform (cl:make-array\n"
       "            0\n"
       "            :element-type '$package$::$type$\n"

--- a/protoc/lisp/message_field.cc
+++ b/protoc/lisp/message_field.cc
@@ -76,6 +76,7 @@ void MessageFieldGenerator::GenerateSlot(io::Printer* printer) const {
       variables_,
       "($name$\n"
       " :writer (cl:setf $name$)\n"
+      " :initarg :$name$\n"
       " :initform cl:nil\n"
       " :type (cl:or cl:null $package$::$type$))\n");
 }
@@ -234,6 +235,7 @@ void RepeatedMessageFieldGenerator::GenerateSlot(io::Printer* printer) const {
       variables_,
       "($name$\n"
       " :accessor $name$\n"
+      " :initarg :$name$\n"
       " :initform (cl:make-array\n"
       "            0\n"
       "            :element-type '$package$::$type$\n"

--- a/protoc/lisp/primitive_field.cc
+++ b/protoc/lisp/primitive_field.cc
@@ -232,6 +232,7 @@ void PrimitiveFieldGenerator::GenerateSlot(io::Printer* printer) const {
       variables_,
       "($name$\n"
       " :accessor $name$\n"
+      " :initarg :$name$\n"
       " :initform $default$\n"
       " :type $type$)\n");
 }
@@ -302,6 +303,7 @@ void RepeatedPrimitiveFieldGenerator::GenerateSlot(io::Printer* printer)
       variables_,
       "($name$\n"
       " :accessor $name$\n"
+      " :initarg :$name$\n"
       " :initform (cl:make-array\n"
       "            0\n"
       "            :element-type '$type$\n"

--- a/protoc/lisp/string_field.cc
+++ b/protoc/lisp/string_field.cc
@@ -80,6 +80,7 @@ void StringFieldGenerator::GenerateSlot(io::Printer* printer) const {
       variables_,
       "($name$\n"
       " :accessor $name$\n"
+      " :initarg :$name$\n"
       " :initform $default$\n"
       " :type $type$)\n");
 }
@@ -167,6 +168,7 @@ void RepeatedStringFieldGenerator::GenerateSlot(io::Printer* printer) const {
       variables_,
       "($name$\n"
       " :accessor $name$\n"
+      " :initarg :$name$\n"
       " :initform (cl:make-array\n"
       "            0\n"
       "            :element-type '$type$\n"


### PR DESCRIPTION
This uses (defmethod initialize-instance :after) methods to ensure
that fields populated with :initargs are recorded into %has-bits%.

Closes issue #16.